### PR TITLE
no concurrency by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,18 @@ This is a metalsmith plugin for pushing build artefacts to azure storage.
 
 ## Usage
 
-TODO
+```javascript
+const azure = require('metalsmith-azure-storage');
+
+metalsmith.use(azure({
+  account: ACCOUNT_NAME,
+  key: ACCOUNT_KEY,
+  container: CONTAINER_NAME,
+
+  /* optional, default: 1 for no concurrency */
+  concurrency: 4
+}));
+```
 
 ## License
 

--- a/lib/metalsmith-azure-storage.js
+++ b/lib/metalsmith-azure-storage.js
@@ -19,7 +19,10 @@ module.exports = function (opts) {
       .createBlobService(opts.account, opts.key)
       .withFilter(new azure.LinearRetryPolicyFilter());
 
-    var q = queue({ concurrency: 4, timeout: 1000 * 60 * 2 });
+    var q = queue({
+      concurrency: opts.concurrency || 1,
+      timeout: 1000 * 60 * 2,
+    });
     var count = 0;
 
     Object.keys(files).forEach(function (path) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-azure-storage",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "pushing projects built with metalsmith to azure storge",
   "main": "lib/metalsmith-azure-storage.js",
   "scripts": {


### PR DESCRIPTION
we were running into this problem: http://stackoverflow.com/questions/12917857/the-specified-block-list-is-invalid-while-uploading-blobs-in-parallel

No sure if it's definitely related to parallelism or not, but it seemed like a good idea to disable the parallelism by default just in case.
